### PR TITLE
Fixed syntax errors in the code example of using DefaultRendererFactory.

### DIFF
--- a/src/prefuse/render/DefaultRendererFactory.java
+++ b/src/prefuse/render/DefaultRendererFactory.java
@@ -31,8 +31,8 @@ import prefuse.visual.VisualItem;
  * "label".</p>
  * <pre>
  *   DefaultRendererFactory rf = new DefaultRendererFactory();
- *   rf.setDefaultEdgeRenderer(new EdgeRenderer(Constants.EDGE_TYPE_CURVE);
- *   rf.add("INGROUP('data')", new LabelRenderer("label");
+ *   rf.setDefaultEdgeRenderer(new EdgeRenderer(Constants.EDGE_TYPE_CURVE));
+ *   rf.add("INGROUP('data')", new LabelRenderer("label"));
  * </pre>
  * 
  * @author <a href="http://jheer.org">jeffrey heer</a>


### PR DESCRIPTION
In the Javadoc comments of DefaultRenderFactory is a small code example of how to use the class. This example has syntax errors as its missing closing brackets. Here is the change to fix this.
