### PR TITLE
CascadedColumnListener removal bug

### DIFF
--- a/src/prefuse/data/CascadedTable.java
+++ b/src/prefuse/data/CascadedTable.java
@@ -159,9 +159,10 @@ public class CascadedTable extends Table {
         
         for ( int i=0; i<m_pnames.size(); ++i ) {
             String name = (String)m_pnames.get(i);
-            Column col = m_parent.getColumn(i);
+            Column col = m_parent.getColumn(name);
             boolean contained = m_names.contains(name);
-            if ( !m_colFilter.include(col, name) || contained ) {
+            boolean removedFromParent = (col == null);
+            if (removedFromParent || !m_colFilter.include(col, name) || contained ) {
                 m_pnames.remove(i--);
                 if ( !contained ) {
                     ((ColumnEntry)m_entries.get(name)).dispose();


### PR DESCRIPTION
this code:

``` java
 /**
     * Determines which columns are inherited from the backing parent table.
     */
    protected void filterColumns() {
        if ( m_parent == null ) return;

        for ( int i=0; i<m_pnames.size(); ++i ) {
            String name = (String)m_pnames.get(i);
            Column col = m_parent.getColumn(i);
```

is a problem if m_pnames is longer than m_parent, which, I believe, happens when you remove something that used to be in m_pnames from the backing table, causing an indexexception of some sort.

So, the question is: is there an easy way around this from the user standpoint, or should we be doing something like:

``` java
      if (m_parent.getColumnIndex(name) < 0) {/*remove column*/ ;}
```

Or am I missing something?
