### PR TITLE
Tree layout fixes

### DIFF
--- a/src/prefuse/action/layout/graph/NodeLinkTreeLayout.java
+++ b/src/prefuse/action/layout/graph/NodeLinkTreeLayout.java
@@ -248,6 +248,8 @@ public class NodeLinkTreeLayout extends TreeLayout {
         
         NodeItem root = getLayoutRoot();
         Params rp = getParams(root);
+
+	g.getSpanningTree(root);
         
         // do first pass - compute breadth information, collect depth info
         firstWalk(root, 0, 1);

--- a/src/prefuse/action/layout/graph/RadialTreeLayout.java
+++ b/src/prefuse/action/layout/graph/RadialTreeLayout.java
@@ -130,6 +130,8 @@ public class RadialTreeLayout extends TreeLayout {
         m_origin = getLayoutAnchor();
         NodeItem n = getLayoutRoot();
         Params np = (Params)n.get(PARAMS);
+
+	g.getSpanningTree(n);
         
         // calc relative widths and maximum tree depth
         // performs one pass over the tree


### PR DESCRIPTION
Fixes RadialTreeLayout and NodeLinkTreeLayout to lay out nodes properly when the layout root is other than the first node in the table.  The graph's spanning tree is null after initSchema().  This change recreates it with the correct root.
