### PR TITLE
Allow spaces in JAVA_HOME directory (Windows build.bat)

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -8,7 +8,7 @@ set ANT_HOME=./lib
 
 echo ... using classpath %LOCALCLASSPATH%
 
-%JAVA_HOME%\bin\java.exe -Dant.home="%ANT_HOME%" -classpath "%LOCALCLASSPATH%" org.apache.tools.ant.Main %1 %2 %3 %4 %5
+"%JAVA_HOME%\bin\java.exe" -Dant.home="%ANT_HOME%" -classpath "%LOCALCLASSPATH%" org.apache.tools.ant.Main %1 %2 %3 %4 %5
 
 goto end
 


### PR DESCRIPTION
Fixes build issue where Java is installed in a folder hierarchy containing spaces.
