### PR TITLE
Bugfix reversely sorted iterator. Member "reverse" was not initialized.

### DIFF
--- a/src/prefuse/util/collections/AbstractTreeMap.java
+++ b/src/prefuse/util/collections/AbstractTreeMap.java
@@ -498,6 +498,7 @@ public abstract class AbstractTreeMap implements IntSortedMap {
         Entry next, end;
 
         EntryIterator(boolean reverse) {
+            this.reverse = reverse;
             next = reverse ? maximum(root) : minimum(root);
             end = NIL;
         }


### PR DESCRIPTION
If you use the method table.rowsSortedBy to iterate over table rows in a
descending order according to some column, as follows
IntIterator sortedRows = table.rowsSortedBy(COLMUN_VALUE, false);
only one row will be retrieved by the iterator.

The problem lies in the inner class EntryIterator, the field reverse
which specifies the sort direction does not get assigned in the 1st
constructor.
