### PR TITLE
Compiling error on Linux

### DIFF
--- a/src/prefuse/action/layout/graph/BalloonTreeLayout.java
+++ b/src/prefuse/action/layout/graph/BalloonTreeLayout.java
@@ -14,9 +14,9 @@ import prefuse.visual.NodeItem;
  * This layout places children nodes radially around their parents, and is
  * equivalent to a top-down flattened view of a ConeTree.</p>
  * 
- * <p>The algorithm used is that of G. Melançon and I. Herman from their
+ * <p>The algorithm used is that of G. Melan\c{c}on and I. Herman from their
  * research paper Circular Drawings of Rooted Trees, Reports of the Centre for 
- * Mathematics and Computer Sciences, Report Number INS–9817, 1998.</p>
+ * Mathematics and Computer Sciences, Report Number INS-9817, 1998.</p>
  *
  * @author <a href="http://jheer.org">jeffrey heer</a>
  */

--- a/src/prefuse/action/layout/graph/NodeLinkTreeLayout.java
+++ b/src/prefuse/action/layout/graph/NodeLinkTreeLayout.java
@@ -19,7 +19,7 @@ import prefuse.visual.NodeItem;
  * tree can be set such that the tree goes left-to-right (default),
  * right-to-left, top-to-bottom, or bottom-to-top.</p>
  * 
- * <p>The algorithm used is that of Christoph Buchheim, Michael Jünger,
+ * <p>The algorithm used is that of Christoph Buchheim, Michael Juenger,
  * and Sebastian Leipert from their research paper
  * <a href="http://citeseer.ist.psu.edu/buchheim02improving.html">
  * Improving Walker's Algorithm to Run in Linear Time</a>, Graph Drawing 2002.

--- a/src/prefuse/util/collections/AbstractHashMap.java
+++ b/src/prefuse/util/collections/AbstractHashMap.java
@@ -1,5 +1,5 @@
 /*
- Copyright © 1999 CERN - European Organization for Nuclear Research.
+ Copyright (c) 1999 CERN - European Organization for Nuclear Research.
  Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
  is hereby granted without fee, provided that the above copyright notice appear in all copies and 
  that both that copyright notice and this permission notice appear in supporting documentation. 

--- a/src/prefuse/util/collections/IntObjectHashMap.java
+++ b/src/prefuse/util/collections/IntObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
- Copyright © 1999 CERN - European Organization for Nuclear Research.
+ Copyright (c) 1999 CERN - European Organization for Nuclear Research.
  Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
  is hereby granted without fee, provided that the above copyright notice appear in all copies and 
  that both that copyright notice and this permission notice appear in supporting documentation. 


### PR DESCRIPTION
When Compiling on a Linux system javac throws several errors complaining about illegal characters in the source (copyright symbol and other non-ascii chars) because sources seem to be in window-ish instead of UTF8.

Either convert to UTF8, or add
          encoding="Cp1252"
to the javac ant task in build.xml
Regards
   Hartmut
