### PR TITLE
Change visibility of TransformActivity from private to protected, as the

### DIFF
--- a/src/prefuse/Display.java
+++ b/src/prefuse/Display.java
@@ -1285,7 +1285,7 @@ public class Display extends JComponent {
     /**
      * Activity for conducting animated view transformations.
      */
-    private class TransformActivity extends Activity {
+    protected class TransformActivity extends Activity {
         // TODO: clean this up to be more general...
         // TODO: change mechanism so that multiple transform
         //        activities can be running at once?


### PR DESCRIPTION
I had to add a listener to the m_transform attribute. It seems as this is the only way to hook onto a zoom animation. However, the attribute m_transform has the protected visibility which gives us promising sort of access with listeners. But the class TransformActivity itself is private. That gives us some restrictions to access m_transform... ;-)
So my pull request is to change the visibility of the class TransformActivity to protected.
