### PR TITLE
build.xml javac encoding attribute

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -126,7 +126,8 @@
     	       classpath="${lucene.lib}"
            debug="${debug}"
            deprecation="${deprecation}"
-           optimize="${optimize}"/>
+           optimize="${optimize}"
+           encoding="cp1252"/>
   </target>
 
   <!-- =================================================================== -->


### PR DESCRIPTION
I added encoding attribute to the javac task in `build.xml`. On Linux, you can't build the project successfully without this because of non utf-8 characters in the source files.
