### PR TITLE
Consider graph ID property in GraphMLWriter as reader supports this

### DIFF
--- a/src/prefuse/data/io/GraphMLWriter.java
+++ b/src/prefuse/data/io/GraphMLWriter.java
@@ -84,8 +84,16 @@ public class GraphMLWriter extends AbstractGraphWriter {
         xml.println();
         
         // print graph contents
-        xml.start(Tokens.GRAPH, Tokens.EDGEDEF,
-            graph.isDirected() ? Tokens.DIRECTED : Tokens.UNDIRECTED);
+        Object graphID = graph.getClientProperty(Tokens.ID);
+        if (graphID == null) {
+            xml.start(Tokens.GRAPH, Tokens.EDGEDEF, graph.isDirected() ? Tokens.DIRECTED : Tokens.UNDIRECTED);
+        }
+        else {
+            xml.start(Tokens.GRAPH,
+                new String[] { Tokens.EDGEDEF, Tokens.ID },
+                new String[] { graph.isDirected() ? Tokens.DIRECTED : Tokens.UNDIRECTED, graphID.toString() },
+                2 );
+        }
         
         // print the nodes
         xml.comment("nodes");


### PR DESCRIPTION
GraphMLReader reads ID field from start node("graph") and put it to clientProperties. This field might be very useful to keep type of graph or it's name, but unfortunately this field is ignored during write graphML as xml.