### PR TITLE
README: point to project site at kneecap.ist.berkeley.edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ MORE
 ----
 
 Additional information and preliminary documentation, a gallery of featured
-prefuse applications, and more, were available at the prefuse website, which is no longer available since 2018.
-A snapshot can be found at <https://web.archive.org/web/20181215222711/http://prefuse.org/>.
+prefuse applications, and more, are available at the prefuse website, hosted
+at UC Berkeley. <http://kneecap.ist.berkeley.edu/>
 
 SourceForge hosts a help forum: <https://sourceforge.net/p/prefuse/discussion/343013/>
 


### PR DESCRIPTION
The original prefuse.org domain has been sold, but this UC Berkeley site
(which was apparently the original actual host) is still live. This presents
a nicer viewing experience than archive.org.

Follows up on #37.